### PR TITLE
RFC: Move to barge-os

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,8 @@ $vm_gui = false
 $vm_memory = 2048
 $vm_cpus = 8
 
+$docker_version = "latest"
+
 def vm_gui
   $vb_gui.nil? ? $vm_gui : $vb_gui
 end
@@ -19,7 +21,7 @@ end
 
 Vagrant.configure("2") do |config|
 
-  config.vm.box = "ailispaw/docker-root"
+  config.vm.box = "ailispaw/barge"
   config.vm.network :private_network, ip: "172.17.8.101"
   config.vm.synced_folder ENV['HOME'], ENV['HOME'], id: "home", :nfs => true, :mount_options => ['noatime,soft,nolock,vers=3,udp,proto=udp,udp,rsize=8192,wsize=8192,namlen=255,timeo=10,retrans=3,nfsvers=3,actimeo=1']
 
@@ -65,9 +67,10 @@ Vagrant.configure("2") do |config|
     sh.inline = "sntp -4sSc pool.ntp.org; date"
   end
 
-  config.vm.provision "shell", inline: "mkdir -p /home/docker/cronjobs", privileged: false
-  config.vm.provision "file", source: "./cronjobs/date.sh", destination: '/home/docker/cronjobs/date.sh'
-  config.vm.provision "file", source: "./crontab", destination: '/home/docker/crontab'
-  config.vm.provision "shell", inline: "cd /home/docker/cronjobs; chmod 755 *.sh", privileged: true
-  config.vm.provision "shell", inline: "cd /home/docker; cat crontab | crontab -;  crontab -l", privileged: true
+  config.vm.provision "shell", inline: "mkdir -p /home/bargee/cronjobs", privileged: false
+  config.vm.provision "file", source: "./cronjobs/date.sh", destination: '/home/bargee/cronjobs/date.sh'
+  config.vm.provision "file", source: "./crontab", destination: '/home/bargee/crontab'
+  config.vm.provision "shell", inline: "cd /home/bargee/cronjobs; chmod 755 *.sh", privileged: true
+  config.vm.provision "shell", inline: "cd /home/bargee; cat crontab | crontab -;  crontab -l", privileged: true
+  config.vm.provision "shell", inline: "/etc/init.d/docker restart #{$docker_version}", privileged: true
 end


### PR DESCRIPTION
Since [docker-root](https://github.com/ailispaw/docker-root) is deprecated, it only makes sense to update to the new [barge-os](https://github.com/bargees/barge-os).

One of the nicer features is that it's easier to switch between docker versions, I haven't personally noticed any performance loss or gain.

Code in the PR should work if you want to try it out.
