### PR TITLE
Pinned docker version to v1.11.2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ $vm_gui = false
 $vm_memory = 2048
 $vm_cpus = 8
 
-$docker_version = "latest"
+$docker_version = "1.11.2"
 
 def vm_gui
   $vb_gui.nil? ? $vm_gui : $vb_gui


### PR DESCRIPTION
As mentioned in [#5](https://github.com/yappabe/vagrant-docker/pull/5#issuecomment-231413812), it's better to pin the docker version than to use `latest`
