### PR TITLE
Add ignore dependencies on docker-compose install

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ vagrant plugin install vagrant-triggers
 #### Docker
 
 ```
-brew install docker docker-compose
+brew install docker 
+brew install docker-compose --ignore-dependencies 
 ```
 
 


### PR DESCRIPTION
By default docker-machine is installed - https://github.com/Homebrew/homebrew-core/blob/master/Formula/docker-compose.rb#L23
A `:recommended` `depends_on` will be installed by default: http://www.rubydoc.info/github/Homebrew/brew/Formula.depends_on