### PR TITLE
[WIP] Upgrade docker, dnsdock and move from ui-for-docker to portainer

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,9 +5,9 @@ $vm_gui = false
 $vm_memory = 2048
 $vm_cpus = 8
 
-$docker_version = "1.13.0"
+$docker_version = "latest"
 $vm_ip_address = "172.17.8.101"
-$docker_net = "172.18.0.0"
+$docker_net = "172.16.0.0/12"
 
 def vm_gui
   $vb_gui.nil? ? $vm_gui : $vb_gui
@@ -73,18 +73,19 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: "/etc/init.d/docker restart #{$docker_version}", privileged: true
 
   config.vm.provision "docker" do |d|
-    d.pull_images "ailispaw/dnsdock:1.16.1"
+    d.pull_images "ailispaw/dnsdock:1.16.4"
     d.run "dnsdock",
-      image: "ailispaw/dnsdock:1.16.1",
+      image: "ailispaw/dnsdock:1.16.4",
       args: "-v /var/run/docker.sock:/var/run/docker.sock -p 0.0.0.0:53:53/udp",
       restart: "always",
       daemonize: true
   end
 
+  # http://portainer.io
   config.vm.provision "docker" do |d|
-    d.pull_images "uifd/ui-for-docker"
-    d.run "ui-for-docker",
-      image: "uifd/ui-for-docker",
+    d.pull_images "portainer/portainer"
+    d.run "portainer/portainer",
+      image: "portainer/portainer",
       args: "-v /var/run/docker.sock:/var/run/docker.sock -p 9000:9000  --privileged",
       restart: "always",
       daemonize: true

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ $vm_gui = false
 $vm_memory = 2048
 $vm_cpus = 8
 
-$docker_version = "latest"
+$docker_version = "17.05.0-ce"
 $vm_ip_address = "172.17.8.101"
 $docker_net = "172.16.0.0/12"
 


### PR DESCRIPTION
# How to upgrade

## Prio upgrade

Upgrade `virtualbox` and `vagrant`. In the `vagrant-docker` folder.
Check if your vagrant or virtualbox casks are outdated.

```
brew cask outdated 
```

If so, reinstall.

```
vagrant halt
brew cask reinstall vagrant
brew cask reinstall virtualbox
```

## Upgrade repo

```
git pull
vagrant box update
```

## Restart vagrant (halt and up)

The `up` command will add the net subnet route.

```
vagrant halt
vagrant up
```


## Remove old containers

`docker ps` for correct names. Docker will cry when it can't kill no such container. 😭

```
docker kill uifd-ui-for-docker
docker rm -v uifd-ui-for-docker
docker kill ailispaw-dnsdock
docker rm -v ailispaw-dnsdock
```

or

```
docker kill ui-for-docker
docker rm -v ui-for-docker
docker kill dnsdock
docker rm -v dnsdock
```

## Provision with new containers

```
vagrant provision
```

## Upgrade locale packages.

* docker-compose —> ^1.13.0
* docker  —>  ^17.05.0
```
brew upgrade docker-compose 
brew upgrade docker
```

Switch versions:

```
brew switch docker-compose 1.13.0
brew switch docker 17.05.0
```

# Docker Compose v3

After this you can upgrade your `docker-compose.yml`.

## Example

```
version: '3'

services:
    nginx:
        image: yappabe/nginx:1.9
        volumes:
            - ./docker/shared/:/shared
            - ./:/var/www/app
        depends_on:
            - php
        env_file: 'app/config/.env'
        environment:
            DNSDOCK_ALIAS: project.docker.webfolks.be, admin.project.docker.webfolks.be

    mysql:
        image: mariadb:10
        env_file: 'app/config/.env'
        environment:
            DNSDOCK_ALIAS: mysql.project.docker.webfolks.be

    php:
        image: yappabe/php:7.1
        volumes:
            - ./docker/shared/:/shared
            - ./:/var/www/app
            - vendor:/vendor
        links:
            - mysql
        working_dir: /var/www/app
        env_file: 'app/config/.env'
        depends_on:
            - mysql
            - mailcatcher

    mailcatcher:
        image: yappabe/mailcatcher
        environment:
            DNSDOCK_ALIAS: mailcatcher.project.docker.webfolks.be

volumes:
  vendor:
```

## .env

A .env file can look like this

```
DOCUMENT_ROOT=/var/www/app/web
INDEX_FILE=app_dev.php
PHP_FPM_SOCKET=php:9000
MYSQL_ROOT_PASSWORD=dev
MYSQL_DATABASE=project
MYSQL_USER=root
MYSQL_HOST=mysql
MYSQL_PORT=3306
PHP_FPM_USER=root
PHP_ERROR_REPORTING=E_ALL
HISTFILE=/shared/.bash_history
MAILER_TRANSPORT=smtp
MAILER_HOST=mailcatcher
MAILER_USER=null
MAILER_PASSWORD=null
MAILER_PORT=1025
MAILER_SECURITY=null
```


# What's new

* Portainer on `http://localhost:9000`
* Project containers are on their own subnet `172.16.0.0/12`
* All new docker features
* Docker-compose v3 
