### PR TITLE
Use native Vagrant triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,6 @@ brew cask install vagrant
 brew cask install virtualbox
 ```
 
-#### Vagrant plugins
-
-```
-vagrant plugin install vagrant-triggers
-```
-
-
 #### Docker
 
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,11 +1,11 @@
 
-Vagrant.require_version ">= 1.7.0"
+Vagrant.require_version ">= 2.1.0"
 
 $vm_gui = false
 $vm_memory = 2048
 $vm_cpus = 8
 
-$docker_version = "17.05.0-ce"
+$docker_version = "18.04.0-ce"
 $vm_ip_address = "172.17.8.101"
 $docker_net = "172.16.0.0/12"
 
@@ -98,20 +98,14 @@ Vagrant.configure("2") do |config|
     EOT
   end
 
-  if Vagrant.has_plugin?("vagrant-triggers") then
-    config.trigger.after [:up, :resume] do
-      info "Setup route to vm ip."
-      run <<-EOT
-        sh -c "sudo route -n add -net #{$docker_net} #{$vm_ip_address}"
-      EOT
-    end
+  config.trigger.after [:up, :resume] do |trigger|
+    trigger.info = "Setup route to vm ip #{$docker_net} -> #{$vm_ip_address}!"
+    trigger.run = {inline: "sudo route -n add -net #{$docker_net} #{$vm_ip_address}"}
+  end
 
-    config.trigger.after [:destroy, :suspend, :halt] do
-      info "Remove route to vm ip."
-      run <<-EOT
-        sh -c "sudo route -n delete -net #{$docker_net} #{$vm_ip_address}"
-      EOT
-    end
+  config.trigger.after [:destroy, :suspend, :halt] do |trigger|
+    trigger.info = "Remove route to vm ip!"
+    trigger.run = {inline: "sudo route -n delete -net #{$docker_net} #{$vm_ip_address}"}
   end
 
 end


### PR DESCRIPTION
Vagrant now has [a native triggers](https://www.vagrantup.com/docs/triggers/
) 'plugin'.

This makes the [vagrant-triggers](https://github.com/emyl/vagrant-triggers) plugin obselete.

**How to upgrade?**

Upgrade to Vagrant version +2.1.0

```
brew cask reinstall vagrant

vagrant --version
Vagrant 2.1.1
```

You can also upgrade `Virtualbox`, but it's not a requirement. This PR is tested on `5.2.12 r122591 (Qt5.6.3)`. Make sure you turn off Virtualbox first.

```
brew cask reinstall virtualbox
```

Remove the old plugin

```
vagrant plugin uninstall vagrant-triggers
```


Upgrade vagrant box

```
vagrant box update

ailispaw/barge' (v2.8.2)
```

Upgrade docker daemon to 18.04.0-ce

```
vagrant provision
```




