### PR TITLE
Wrong container network address

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,8 @@ $vm_gui = false
 $vm_memory = 2048
 $vm_cpus = 8
 
-$docker_version = "18.04.0-ce"
+
+$docker_version = "18.06.0-ce"
 $vm_ip_address = "172.17.8.101"
 $docker_net = "172.16.0.0/12"
 

--- a/docker
+++ b/docker
@@ -5,7 +5,7 @@
 # DOCKER_HOST="-H unix://"
 DOCKER_HOST="-H unix:// -H tcp://0.0.0.0:2375"
 
-DOCKER_EXTRA_ARGS="--bip 172.18.0.1/24"
+DOCKER_EXTRA_ARGS="--default-address-pool base=172.16.0.0/12,size=24 --bip 172.18.0.1/24"
 
 # DOCKER_ULIMITS=1048576
 


### PR DESCRIPTION
Docker (compose) creates a "private" network for each "project".
We want these container networks forced in the `172.16.0.0/12` range. Because we add a route on Mac to route all traffic to the Vagrant VM IP for all `172.16.0.0/12` addresses.

Source: https://github.com/yappabe/vagrant-docker/blob/master/Vagrantfile#L103

This fix will force docker to create networks in the `172.16.0.0/12` range for all **NEW** networks.

**Notice: The server (Vagrant VM) docker version should be at least _18.06.0-ce_**

Update docker version

```bash
vagrant provision
vagrant halt
vagrant up
```

```bash
$ docker version
Client:
  ...
Server:
 Engine:
  Version:      18.06.0-ce
  API version:  1.38 (minimum version 1.12)
  Go version:   go1.10.3
  Git commit:   0ffa825
  Built:        Wed Jul 18 19:13:39 2018
  OS/Arch:      linux/amd64
  Experimental: false
```

When you have already a project in the wrong range (e.g. 192.168.x.x) :
 
1. Stop containers: `docker-compose stop`
2. Remove containers: `docker-compose rm`
3. Find the network: `docker network ls`
4. Remove the network: `docker  network remove project_x_default`
5. Re-up the container: `docker-compose up -d`

A new network in the correct range is created:
```
Creating network "project_x_default" with the default driver`
```

Double check with:
```
 docker network inspect project_x_default
```




